### PR TITLE
chore: eliminar lineas innecesarias

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/com/example/hotelsierra/controlador/ControladorInicio.java
+++ b/src/main/java/com/example/hotelsierra/controlador/ControladorInicio.java
@@ -3,15 +3,12 @@ package com.example.hotelsierra.controlador;
 import com.example.hotelsierra.modelo.Habitacion;
 import com.example.hotelsierra.modelo.InformeHabitaciones;
 import com.example.hotelsierra.modelo.Inicio;
-import com.example.hotelsierra.modelo.Reserva;
-import com.itextpdf.layout.borders.Border;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
-import javafx.geometry.Side;
 import javafx.util.Callback;
 
 


### PR DESCRIPTION
Elimina líneas de importación de librerías que ya no se utilizaban en el archivo ControladorInicio.

Este cambio limpia el código y evita dependencias innecesarias.
